### PR TITLE
fix: Enable tree shaking via sideEffects: false

### DIFF
--- a/packages/drift/package.json
+++ b/packages/drift/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.cjs",
+  "sideEffects": false,
   "types": "dist/index.d.cts",
   "exports": {
     ".": {


### PR DESCRIPTION
sideEffects false tells bundlers like webpack that this node_module does not have side effects so any unused exports can be safely tree shaken. This will make the bundle size hit from drift minimal